### PR TITLE
Improve cache invalidation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+- Improve cache invalidation. (#13)
+  [ale-rt]
+
 - Remove imports deprecated a decade ago.
   [ale-rt]
 

--- a/Products/MemcachedManager/tests/testMemcachedManager.py
+++ b/Products/MemcachedManager/tests/testMemcachedManager.py
@@ -19,6 +19,15 @@ class TestMemcachedManager(mcmtc.MemcachedManagerTestCase):
         cache = self._cache
         self.assertTrue(cache)
 
+    def testCache_get_counter_value(self):
+        cache = self._cache
+        ob = self._script
+        with self.assertRaises(AttributeError):
+            getattr(ob, cache.cachecountervariable)
+        value = cache._get_counter_value(ob=ob)
+        self.assertIsInstance(value, int)
+        self.assertEqual(value, getattr(ob, cache.cachecountervariable))
+
     def testCacheSetGet(self):
         cache = self._cache
         ob = self._script


### PR DESCRIPTION
This PR initializes the cache counter that will be used to generate the cache key with a random number rather than with a 0.
This will decrease the chance of reusing a stale cached value.

Fixes #13