### PR TITLE
Fix the memcached manager edit form

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,12 @@
 Changelog
 =========
 
-1.3 (unreleased)
-----------------
+1.2.1 (unreleased)
+------------------
 
-- Nothing changed yet.
+- Editing the memcached manager properties through the web results
+  in storing values with the proper data type. (#15)
+  [ale-rt]
 
 
 1.2 (2021-01-04)

--- a/Products/MemcachedManager/MemcachedManager.py
+++ b/Products/MemcachedManager/MemcachedManager.py
@@ -455,8 +455,7 @@ class MemcachedManager(CacheManager, SimpleItem):
         if settings is None:
             settings = REQUEST
         self.title = safe_nativestring(title)
-        request_vars = list(settings["request_vars"])
-        request_vars.sort()
+        request_vars = sorted(safe_nativestring(r) for r in settings["request_vars"])
         servers = [safe_nativestring(s) for s in list(settings["servers"]) if s]
         mirrors = [safe_nativestring(m) for m in list(settings.get("mirrors", [])) if m]
         debug = int(settings.get("debug", 0))

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages
 from setuptools import setup
 
 
-version = "1.3.dev0"
+version = "1.2.1.dev0"
 description = "Memcached cache manager for Zope."
 long_description = open("README.rst").read() + "\n" + open("CHANGES.rst").read()
 


### PR DESCRIPTION
Editing the memcached manager properties through the web results in storing values with the proper data type.

Fixes #15